### PR TITLE
Add support for backdrop-filter, among other stuff

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -198,6 +198,7 @@ def main():
                 entire_thing = f.read()
 
             entire_thing = entire_thing.replace("mainWindow.webContents.on('dom-ready', function () {});", css_reload_script)
+            entire_thing = entire_thing.replace("\nmain();", "\napp.commandLine.appendSwitch('--enable-experimental-web-platform-features');main();")
 
             with open('./app/index.js', 'w') as f:
                 f.write(entire_thing)


### PR DESCRIPTION
The [backdrop-filter](https://webkit.org/blog/3632/introducing-backdrop-filters/) CSS adds many possibilities, but it's only available through the `--enable-experimental-web-platform-features` flag.

While one can edit all discord launchers and shortcuts to include the flag, wouldn't it be nice to have this integrated into BeautifulDiscord itself? (since it's focused at styling)

Thankfully, the Electron API provides a method to add chrome flags before launching the renderer process, and this PR makes use of said API to add the cli switch.

This might also allow some other experimental CSS features.