### PR TITLE
Allows external style sheets to load again v2

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -195,7 +195,7 @@ def revert_changes(discord):
     discord.launch()
 
 def allow_https():
-	bypass_csp = "\n\nelectron.webFrame.registerURLSchemeAsBypassingCSP('https');"
+	bypass_csp = "\n\nrequire('electron').webFrame.registerURLSchemeAsBypassingCSP('https');"
 	
 	with open('./core/app/mainScreenPreload.js', 'a', encoding='utf-8') as f:
 		f.write(bypass_csp)

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -195,7 +195,7 @@ def revert_changes(discord):
     discord.launch()
 
 def allow_https():
-	bypass_csp = "\n\n\n\nwebFrame.registerURLSchemeAsBypassingCSP('https');"
+	bypass_csp = "\n\nwebFrame.registerURLSchemeAsBypassingCSP('https');"
 	
 	with open('./core/app/discord_native/window.js', 'a', encoding='utf-8') as f:
 		f.write(bypass_csp)

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -195,9 +195,9 @@ def revert_changes(discord):
     discord.launch()
 
 def allow_https():
-	bypass_csp = "\n\nrequire('electron').webFrame.registerURLSchemeAsBypassingCSP('https');"
+	bypass_csp = "\n\n\n\nwebFrame.registerURLSchemeAsBypassingCSP('https');"
 	
-	with open('./core/app/mainScreenPreload.js', 'a', encoding='utf-8') as f:
+	with open('./core/app/discord_native/window.js', 'a', encoding='utf-8') as f:
 		f.write(bypass_csp)
 
 def main():


### PR DESCRIPTION
~~they made changes to make "electron" not defined in the screen-preload (Carnary), so lets just define it ourselves~~

Some users were experiencing the error even after we redefined `electron`, so it would work with some users while with others it didn't (weird).

This method seems to work across the board since it's going right into the window module.

(the error produced that we're fixing)

![error](https://pierce.is-serious.business/e46bf4.png)