### PR TITLE
Add a fix for NixOS support

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -151,7 +151,7 @@ def discord_process():
         except (psutil.Error, OSError):
             pass
         else:
-            exe.replace('.Discord-wrapped', 'Discord') # NixOS wraps the executable instead of launching it directly
+            exe = exe.replace('.Discord-wrapped', 'Discord') # NixOS wraps the executable instead of launching it directly
             if exe.startswith('Discord') and not exe.endswith('Helper'):
                 entry = executables.get(exe)
 

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -151,6 +151,7 @@ def discord_process():
         except (psutil.Error, OSError):
             pass
         else:
+            exe.replace('.Discord-wrapped', 'Discord') # NixOS wraps the executable instead of launching it directly
             if exe.startswith('Discord') and not exe.endswith('Helper'):
                 entry = executables.get(exe)
 


### PR DESCRIPTION
Adds a simple replacement to detect the executable folder on NixOS.

(if anyone stumbles upon this from searching how to get beautifuldiscord on NixOS then here's the derivation:) 

```nix
python36Packages.buildPythonApplication rec {
  pname = "beautifuldiscord";
  version = "1.0";
  src = fetchurl {
    url = "https://github.com/leovoel/BeautifulDiscord/archive/master.zip";
    sha256 = "600590722faa28ea7a0c982b8c7a13a5af067e91017714209d7a4afbc7244dde";
  };
  patches = [ (pkgs.writeText "fix-executable-finder.patch" ''
    diff --git a/beautifuldiscord/app.py b/BeautifulDiscord/>
    index 1680c9e..7f0c903 100644
    --- a/beautifuldiscord/app.py
    +++ b/beautifuldiscord/app.py
    @@ -151,6 +151,7 @@ def discord_process():
             except (psutil.Error, OSError):
                 pass
             else:
    +            exe = exe.replace('.Discord-wrapped', 'Discord') # fix for nixos
                 if exe.startswith('Discord') and not exe.endswith('Helper'):
                     entry = executables.get(exe)
    '')];
  doCheck = false;
  propagatedBuildInputs = with python36Packages; [ psutil ];
}
```