### PR TITLE
Fix for some users not being able to find Discord.

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -151,7 +151,7 @@ def discord_process():
         except (psutil.Error, OSError):
             pass
         else:
-            if exe.startswith('Discord') and not exe.endswith('Helper'):
+            if 'discord' in exe.lower() and not 'Helper' in exe.lower():
                 entry = executables.get(exe)
 
                 if entry is None:

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -151,7 +151,7 @@ def discord_process():
         except (psutil.Error, OSError):
             pass
         else:
-            if 'discord' in exe.lower() and not 'Helper' in exe.lower():
+            if 'discord' in exe.lower() and not 'helper' in exe.lower():
                 entry = executables.get(exe)
 
                 if entry is None:


### PR DESCRIPTION
Some people have been having trouble finding discord and being given; " Could not find Discord executable" this is mainly due to the change in discord name in different installation. As such it is related to;

fixes #62 
fixes #25 

 and supersedes; Pull Request #63 