### PR TITLE
Fixes BeauD from crashing

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -195,10 +195,18 @@ def revert_changes(discord):
     discord.launch()
 
 def allow_https():
-	bypass_csp = "\n\nwebFrame.registerURLSchemeAsBypassingCSP('https');"
-	
-	with open('./core/app/discord_native/window.js', 'a', encoding='utf-8') as f:
-		f.write(bypass_csp)
+    bypass_csp = textwrap.dedent("""
+    require("electron").session.defaultSession.webRequest.onHeadersReceived(function(details, callback) {
+        if (!details.responseHeaders["content-security-policy"]) return callback({cancel: false});
+        details.responseHeaders["content-security-policy"] = "connect-src https://*";
+        callback({cancel: false, responseHeaders: details.responseHeaders});
+    });
+    """)
+    
+    with open('./index.js', 'r+', encoding='utf-8') as f:
+        content = f.read()
+        f.seek(0, 0)
+        f.write(bypass_csp + '\n' + content)
 
 def main():
     args = parse_args()


### PR DESCRIPTION
... and not loading external style sheets

Electron v5 deprecated `registerURLSchemeAsBypassingCSP` apparently, here's a fix. Doesn't allow insecure content to be loaded like the other method.

fixes the following error
![image](https://camo.githubusercontent.com/a52a0ac2724077d562d0e71281d437744b086975/68747470733a2f2f692e616c6578666c69706e6f74652e6465762f344874636944642e706e67)