### PR TITLE
Use XDG_CONFIG_HOME instead of ~/.config

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -72,7 +72,7 @@ class DiscordProcess:
             # To get the version number we have to iterate over ~/.config/discordcanary and find the
             # folder with the highest version number
             discord_version = os.path.basename(self.path).replace('-', '')
-            config = os.path.expanduser(os.path.join('~/.config', discord_version))
+            config = os.path.expanduser(os.path.join(os.getenv('XDG_CONFIG_HOME', '~/.config'), discord_version))
 
             versions_found = {}
             for subdirectory in os.listdir(config):


### PR DESCRIPTION
Try to read from `XDG_CONFIG_HOME` before using `~/.config`, doesn't break anything but makes it work for people who prefer to set `XDG_CONFIG_HOME` themselves.