### PR TITLE
Just outright remove those headers..

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.buildinfo
 *.egg-info
+build/
+dist/

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -196,11 +196,12 @@ def revert_changes(discord):
 
 def allow_https():
     bypass_csp = textwrap.dedent("""
-    require("electron").session.defaultSession.webRequest.onHeadersReceived(function(details, callback) {
-        let csp = details.responseHeaders["content-security-policy"];
-        if (!csp) return callback({cancel: false});
-        details.responseHeaders["content-security-policy"] = csp[0].replace(/connect-src ([^;]+);/, "connect-src $1 https://*; style-src-elem 'unsafe-inline' $1 https://*;");
-        callback({cancel: false, responseHeaders: details.responseHeaders});
+    require("electron").session.defaultSession.webRequest.onHeadersReceived(({ responseHeaders }, done) => {
+      Object.keys(responseHeaders)
+      .filter(k => (/^content-security-policy/i).test(k) || (/^x-frame-options/i).test(k))
+      .map(k => (delete responseHeaders[k]));
+
+      done({ responseHeaders });
     });
     """)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name='BeautifulDiscord',
     author='leovoel',
     url='https://github.com/leovoel/BeautifulDiscord',
-    version='0.1.0',
+    version='0.1.1',
     license='MIT',
     description='Adds custom CSS support to Discord.',
     long_description=readme,


### PR DESCRIPTION
Could be just easier to completely remove the headers instead of adding `https://*` to the current one.
The current method didn't work when trying to use a background-image src from somewhere else other than discordapp CDN.