### PR TITLE
Fix injection not working

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -345,33 +345,33 @@ def main():
     """ % css_injection_script)
 
     load_file_script = textwrap.dedent("""\
-        const fs = require('fs');
-        const path = require('path');
+        const bd_fs = require('fs');
+        const bd_path = require('path');
 
         contextBridge.exposeInMainWorld('BeautifulDiscord', {
             loadFile: (fileName) => {
-                return fs.readFileSync(fileName, 'utf-8');
+                return bd_fs.readFileSync(fileName, 'utf-8');
             },
             readDir: (p) => {
-                return fs.readdirSync(p);
+                return bd_fs.readdirSync(p);
             },
             pathExists: (p) => {
-                return fs.existsSync(p);
+                return bd_fs.existsSync(p);
             },
             watcher: (p, cb) => {
-                return fs.watch(p, { encoding: "utf-8" }, cb);
+                return bd_fs.watch(p, { encoding: "utf-8" }, cb);
             },
             join: (a, b) => {
-                return path.join(a, b);
+                return bd_path.join(a, b);
             },
             basename: (p) => {
-                return path.basename(p);
+                return bd_path.basename(p);
             },
             dirname: (p) => {
-                return path.dirname(p);
+                return bd_path.dirname(p);
             },
             isDirectory: (p) => {
-                return fs.lstatSync(p).isDirectory()
+                return bd_fs.lstatSync(p).isDirectory()
             }
         });
 

--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -382,10 +382,14 @@ def main():
     with open(discord.preload_script, 'rb') as fp:
         preload = fp.read()
 
-    preload = preload.replace(b"process.once('loaded', () => {", load_file_script.encode('utf-8'), 1)
+    if b"contextBridge.exposeInMainWorld('BeautifulDiscord'," not in preload:
+        preload = preload.replace(b"process.once('loaded', () => {", load_file_script.encode('utf-8'), 1)
 
-    with open(discord.preload_script, 'wb') as fp:
-        fp.write(preload)
+        with open(discord.preload_script, 'wb') as fp:
+            fp.write(preload)
+    else:
+        print('info: preload script has already been injected, exiting')
+        return
 
     with open(discord.script_file, 'rb') as f:
         entire_thing = f.read()


### PR DESCRIPTION
In the latest Canary updates they updated Electron to the latest beta which came with contextIsolation: true flag being set. This PR makes it so even if the context isolation is enabled, that the injected script works as-is and plays fair with the system. This requires another injection point (the preload script). 

If Canary is broken for you feel free to try this PR. I'll merge this once this hits stable.