### PR TITLE
fix csp to also load fonts

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -219,6 +219,7 @@ def allow_https():
       let header = csp[0].replace(/connect-src ([^;]+);/, "connect-src $1 https://*;");
       header = header.replace(/style-src ([^;]+);/, "style-src $1 https://*;");
       header = header.replace(/img-src ([^;]+);/, "img-src $1 https://*;");
+      header = header.replace(/font-src ([^;]+);/, "font-src $1 https://*;");
       responseHeaders["content-security-policy"] = header;
       done({ responseHeaders });
     });


### PR DESCRIPTION
The content security policy does not allow fonts, but allows loading things like styles or images, so I figured to also allow loading fonts because when making my discord CSS I was getting errors in console about CSP not loading fonts.