### PR TITLE
add sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ install it as a script that you can run from anywhere.
 ## Installing
 
 ```
-python3 -m pip install -U https://github.com/leovoel/BeautifulDiscord/archive/master.zip
+sudo python3 -m pip install -U https://github.com/leovoel/BeautifulDiscord/archive/master.zip
 ```
 
 Usage of a virtual environment is recommended, to not pollute your global package space.


### PR DESCRIPTION
add sudo to the installation command because in the examples above you are running `beautifuldiscordcss` not using `python` and its assumed that the user installed the script without sudo, so might cause a little confusion for newbies.. 