### PR TITLE
Move injected stylesheet after </body>

### DIFF
--- a/beautifuldiscord/app.py
+++ b/beautifuldiscord/app.py
@@ -272,7 +272,7 @@ def main():
           var customCSS = window.BeautifulDiscord.loadFile(path);
           if (!window._styleTag.hasOwnProperty(name)) {
             window._styleTag[name] = document.createElement("style");
-            document.head.appendChild(window._styleTag[name]);
+            document.documentElement.appendChild(window._styleTag[name]);
           }
           window._styleTag[name].innerHTML = customCSS;
         }


### PR DESCRIPTION
This commit moves the stylesheet after body's closing tag as to bypass Discord's stylesheet loading after this one.

Discord made a recent change which put their stylesheet and most script files inside `<body>` and after `#app-mount`. I've not tested the edited JavaScript but it should work as a quick `a=document.createElement("style");document.documentElement.appendChild(a);` added it after `</body>`.